### PR TITLE
Adding NRWeights into limit trees

### DIFF
--- a/bin/LimitTreeMaker.C
+++ b/bin/LimitTreeMaker.C
@@ -9,8 +9,9 @@
 using namespace std;
 
 int Process(string file, string outFile, string mtotMin, string mtotMax,string scale, 
-		string photonCR, string doKinFit, string doMX, string doTilt, string tiltWindow, 
-		string doNoCat, string btagWP, string doCatMixed, string btagHigh, string btagLow, string singleCat){
+	    string photonCR, string doKinFit, string doMX, string doTilt, string tiltWindow, 
+	    string doNoCat, string btagWP, string doCatMixed, string btagHigh, string btagLow, string singleCat,
+	    string doNRWeights){
     TFile* iFile = new TFile(TString(file), "READ");
     TTree* iTree = (TTree*) iFile->Get("bbggSelectionTree");
     cout << "[LimitTreeMaker:Process] Processing tree with " << iTree->GetEntries() << " entries." << endl;
@@ -30,6 +31,8 @@ int Process(string file, string outFile, string mtotMin, string mtotMax,string s
     t.SetBTagWP_High( TString(btagHigh).Atof());
     t.SetBTagWP_Low( TString(btagLow).Atof());
     t.DoSingleCat( TString(singleCat).Atoi());
+
+    t.DoNRWeights( TString(doNRWeights).Atoi());
     t.Loop();
 
 //    delete iFile;
@@ -57,42 +60,56 @@ int main(int argc, char *argv[]) {
     string singleCat = "0";
     string inputRootFile = "";
 
+    string doNRWeights = "0";
+    
+    cout<<"\t argc =  "<<argc<<endl;
     for( int i = 1; i < argc; i++){
-	if ( std::string(argv[i]) == "-i"){
-		if ( (i+1) == argc) {
-			std::cout << "Invalid number of arguments!" << std::endl;
-			break;
-		}
-		inputFile = string(std::string(argv[i+1]));
-		i++;
+      cout<<"My args:  "<<i<<"  "<<argv[i]<<endl;
+    }
+    
+    for( int i = 1; i < argc; i++){
+
+      cout<<"My args:  "<<i<<"  "<<argv[i]<<endl;
+      if ( std::string(argv[i]) == "-i"){
+	cout<<"iiii We are here"<<endl;
+	if ( (i+1) == argc) {
+	  std::cout << "Invalid number of arguments!" << std::endl;
+	  break;
 	}
-    if ( std::string(argv[i]) == "-inputFile") {
+	inputFile = string(std::string(argv[i+1]));
+	i++;
+      }
+      else if ( std::string(argv[i]) == "-inputFile") {
         if ( (i+1) == argc) {
-            std::cout << "Invaliv number of arguments!" << std::endl;
-            break;
+	  std::cout << "Invaliv number of arguments!" << std::endl;
+	  break;
         }
         inputRootFile = string(std::string(argv[i+1]));
         i++;
-    }
-	else if ( std::string(argv[i]) == "-tilt"){
-		doTilt = "1";
+      }
+      else if ( std::string(argv[i]) == "-NRW"){
+	doNRWeights = "1";
+      }
+      else if ( std::string(argv[i]) == "-tilt"){
+	doTilt = "1";
+      }
+      else if ( std::string(argv[i]) == "-tiltWindow"){
+	if( (i+1) == argc){
+	  std::cout << "Invalid number of arguments!" << std::endl;
+	  break;
 	}
-	else if ( std::string(argv[i]) == "-tiltWindow"){
-		if( (i+1) == argc){
-			std::cout << "Invalid number of arguments!" << std::endl;
-			break;
-		}
-		tiltWindow = string(std::string(argv[i+1]));
-		i++;
+	tiltWindow = string(std::string(argv[i+1]));
+	i++;
+      }
+      else if ( std::string(argv[i]) =="-o"){
+	cout<<"\t ooo We are here"<<endl;
+	if ( (i+1) == argc) {
+	  std::cout << "Invalid number of arguments!" << std::endl;
+	  break;
 	}
-	else if ( std::string(argv[i]) =="-o"){
-		if ( (i+1) == argc) {
-			std::cout << "Invalid number of arguments!" << std::endl;
-			break;
-		}
-		outputLocation = string(std::string(argv[i+1]));
-		i++;
-	}
+	outputLocation = string(std::string(argv[i+1]));
+	i++;
+      }
 	else if ( std::string(argv[i]) =="-max"){
 		if ( (i+1) == argc) {
 			std::cout << "Invalid number of arguments!" << std::endl;
@@ -160,6 +177,9 @@ int main(int argc, char *argv[]) {
 		singleCat = "1";
 	}
 	else {
+
+	  cout<<"Are we here or something?"<<endl;
+
 		cout << "Usage: LimitTreeMaker -i <input list of files> ( or -inputFile <single root file> ) -o <output location>" << endl;// \n
 		cout << "options: " << endl;//\n
 		cout << "\t -min <min mtot> -max <max mtot> " << endl;//\n
@@ -207,7 +227,7 @@ int main(int argc, char *argv[]) {
         outF.append("/LT_");
         outF.append(inputRootFile.substr(sLoc+1));
         cout << "Output file: " << outF << endl;
-        Process(inputRootFile, outF, mtotMin, mtotMax, scale, photonCR, doKinFit, doMX, doTilt, tiltWindow, doNoCat, btagWP, doCatMixed, btagHigh, btagLow, singleCat);
+        Process(inputRootFile, outF, mtotMin, mtotMax, scale, photonCR, doKinFit, doMX, doTilt, tiltWindow, doNoCat, btagWP, doCatMixed, btagHigh, btagLow, singleCat, doNRWeights);
         return 0;
     }
     
@@ -230,7 +250,7 @@ int main(int argc, char *argv[]) {
         outF.append("/LT_");
         outF.append(line.substr(sLoc+1));
         cout << "Output file: " << outF << endl;
-        Process(line, outF, mtotMin, mtotMax, scale, photonCR, doKinFit, doMX, doTilt, tiltWindow, doNoCat, btagWP, doCatMixed, btagHigh, btagLow, singleCat);
+        Process(line, outF, mtotMin, mtotMax, scale, photonCR, doKinFit, doMX, doTilt, tiltWindow, doNoCat, btagWP, doCatMixed, btagHigh, btagLow, singleCat, doNRWeights);
     }
     
     return 0;

--- a/interface/bbggLTMaker.h
+++ b/interface/bbggLTMaker.h
@@ -34,6 +34,12 @@ public :
 //   Output file and tree
    TTree *outTree;
    TFile *outFile;
+
+   ULong64_t o_evt;
+   UInt_t o_run;
+
+   Float_t  o_NRWeights[1507];
+
    Int_t           o_category;
    Double_t        o_normalization;
    Double_t        o_weight;
@@ -54,10 +60,14 @@ public :
    int doNoCat;
    int doCatMixed;
    int doSingleCat;
+   int doNonResWeights;
    double tiltWindow;
    typedef ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > LorentzVector;
 
    // Declaration of leaf types
+
+   Float_t         NRWeights[1507];
+
    vector<double>   *genWeights;
    Double_t         genTotalWeight;
    LorentzVector    *leadingPhoton;
@@ -83,7 +93,14 @@ public :
    Int_t	isSignal;
    Int_t	isPhotonCR;
 
+   ULong64_t event;
+   UInt_t run;
+
    // List of branches
+   TBranch        *b_event;   //!
+   TBranch        *b_run;   //!
+
+   TBranch        *b_NRWeights;   //!                                                                                                                       
    TBranch        *b_genWeights;   //!
    TBranch        *b_genTotalWeight;   //!
    TBranch        *b_leadingPhoton;   //!
@@ -132,6 +149,9 @@ public :
    void DoNoCat( int cat ) { doNoCat = cat; }
    void DoCatMixed( int cat ) { doCatMixed = cat; }
    void DoSingleCat( int cat ) { doSingleCat = cat; }
+
+   void DoNRWeights(int doNRW) { doNonResWeights = doNRW; }
+
 //   void SetTilt( int tt, double ttWind) { tilt = tt; tiltWindow = ttWind; }
    void SetTilt( int tt) { tilt = tt;}
 };
@@ -154,6 +174,8 @@ bbggLTMaker::bbggLTMaker(TTree *tree) : fChain(0)
    doNoCat = 0;
    doCatMixed = 0;
    doSingleCat = 0;
+
+   doNonResWeights = 0;
    Init(tree);
 }
 
@@ -213,6 +235,10 @@ void bbggLTMaker::Init(TTree *tree)
    if (!tree) return;
    fChain = tree;
 //   fChain->SetMakeClass(1);
+   fChain->SetBranchAddress("event", &event, &b_event);
+   fChain->SetBranchAddress("run", &run, &b_run);
+
+   fChain->SetBranchAddress("NRWeights", NRWeights, &b_NRWeights);
 
    fChain->SetBranchAddress("genWeights", &genWeights, &b_genWeights);
    fChain->SetBranchAddress("genTotalWeight", &genTotalWeight, &b_genTotalWeight);

--- a/src/bbggLTMaker.cc
+++ b/src/bbggLTMaker.cc
@@ -14,6 +14,10 @@ void bbggLTMaker::Loop()
 //      Root > t.Show(16);     // Read and show values of entry 16
 //      Root > t.Loop();       // Loop on all entries
 //
+  o_evt = 0;
+  o_run = 0;
+
+  for (UInt_t n=0; n<1507; n++) o_NRWeights[n]=0;
 
    o_weight = 0;
    o_bbMass = 0;
@@ -33,6 +37,11 @@ void bbggLTMaker::Loop()
    outTree->Branch("mgg", &o_ggMass, "o_ggMass/D");
    outTree->Branch("mtot", &o_bbggMass, "o_bbggMass/D"); //
 
+   outTree->Branch("evt", &o_evt, "o_evt/l");
+   outTree->Branch("run", &o_run, "o_run/i");
+
+   outTree->Branch("NRWeights", o_NRWeights, "o_NRWeights[1507]/F");
+
    if (fChain == 0) return;
 
    Long64_t nentries = fChain->GetEntriesFast();
@@ -43,7 +52,13 @@ void bbggLTMaker::Loop()
       if (ientry < 0) break;
       nb = fChain->GetEntry(jentry);   nbytes += nb;
 
-     if( jentry%1000 == 0 ) std::cout << "[bbggLTMaker::Process] Reading entry #" << jentry << endl;   
+     if( jentry%10000 == 0 ) std::cout << "[bbggLTMaker::Process] Reading entry #" << jentry << endl;   
+
+     o_evt = event;
+     o_run = run;
+
+     if (doNonResWeights) 
+       for (UInt_t n=0; n<1507; n++) o_NRWeights[n]=NRWeights[n];
    
      o_weight = genTotalWeight*normalization;
      o_bbMass = dijetCandidate->M();
@@ -94,7 +109,7 @@ void bbggLTMaker::Loop()
       }*/
 //      o_category = 2;
 //
-	if(doCatMixed == 1)
+     if(doCatMixed == 1)
 	{
 	  if (o_category == 2 && ( leadingJet_bDis > btagWP_high || subleadingJet_bDis > btagWP_high ) ) {o_category = 0;}
 	  if (o_category == 2 && leadingJet_bDis < btagWP_high && subleadingJet_bDis < btagWP_high && subleadingJet_bDis > 0.8 ) {o_category = 1;}


### PR DESCRIPTION
This one should add the NRWeights from FlatTrees to LimitTrees.
In order to enable it, must use `-NRW` option.

It also adds event and run numbers.
