### PR TITLE
Recover grid based Non-Res re-weighting

### DIFF
--- a/MORIOND17_MakeNonResLimitTrees.sh
+++ b/MORIOND17_MakeNonResLimitTrees.sh
@@ -26,27 +26,34 @@ for MM in 350 ;
 do
 
 #samples on EOS
-L_SIGNAL=/tmp/rateixei/eos/cms/store/group/phys_higgs/resonant_HH/RunII/FlatTrees/2016/Mar22_Moriond_Spring16Reg_v10/EGML_Signal_v10/Hadd/
-L_BACKGROUND=/tmp/rateixei/eos/cms/store/group/phys_higgs/resonant_HH/RunII/FlatTrees/2016/Mar22_Moriond_Spring16Reg_v10/EGML_Background_v10/Hadd/
-L_DATA=/tmp/rateixei/eos/cms/store/group/phys_higgs/resonant_HH/RunII/FlatTrees/2016/Mar22_Moriond_Spring16Reg_v10/EGML_Data_v10/Hadd/
+    
+    
+    # L_SIGNAL=root://eoscms.cern.ch//eos/cms/store/group/phys_higgs/resonant_HH/RunII/FlatTrees/2016/April26_Mjj70to190/EGML_Signal_Mjj70to190/Hadd
+    L_SIGNAL=./FlatTrees-May02-Sig
+    L_BACKGROUND=root://eoscms.cern.ch//eos/cms/store/group/phys_higgs/resonant_HH/RunII/FlatTrees/2016/April26_Mjj70to190/EGML_Background_Mjj70to190/Hadd
+    L_DATA=root://eoscms.cern.ch//eos/cms/store/group/phys_higgs/resonant_HH/RunII/FlatTrees/2016/April26_Mjj70to190/EGML_Data_Mjj70to190/Hadd
 
 HERE=${PWD}
 
 L_OUTDIR=LT_${MM}_HMHPC_${C0}_HMMPC_${M1}_LMHPC_${C1}_LMMPC_${M2}
 
-python scripts/makeAllTrees.py -x nonres -d ${L_DATA} -s ${L_SIGNAL} -f ${L_OUTDIR} --doCatMVA --MVAHMC0 0.${C0} --MVAHMC1 0.${M1} --MVALMC0 0.${C1} --MVALMC1 0.${M2} --massNR ${MM} --onlySMHH --LMLJBTC ${LMLJBTC} --LMSJBTC ${LMSJBTC};
+# For Non-Res samples, including the weights:
+python scripts/makeAllTrees.py -x nonres -d 0 -s ${L_SIGNAL} -f ${L_OUTDIR} --NRW --doCatMVA --MVAHMC0 0.${C0} --MVAHMC1 0.${M1} --MVALMC0 0.${C1} --MVALMC1 0.${M2} --massNR ${MM} --LMLJBTC ${LMLJBTC} --LMSJBTC ${LMSJBTC};
 
-python scripts/makeAllTrees.py -x nonres -s ${L_BACKGROUND} -d 0 -f ${L_OUTDIR} --doCatMVA --MVAHMC0 0.${C0} --MVAHMC1 0.${M1} --MVALMC0 0.${C1} --MVALMC1 0.${M2} --massNR ${MM} --doSMHiggs --LMLJBTC ${LMLJBTC} --LMSJBTC ${LMSJBTC} --genDiPhotonFilter ;
+#python scripts/makeAllTrees.py -x nonres -d ${L_DATA} -s ${L_SIGNAL} -f ${L_OUTDIR} --doCatMVA --MVAHMC0 0.${C0} --MVAHMC1 0.${M1} --MVALMC0 0.${C1} --MVALMC1 0.${M2} --massNR ${MM} --onlySMHH --LMLJBTC ${LMLJBTC} --LMSJBTC ${LMSJBTC};
+
+#python scripts/makeAllTrees.py -x nonres -s ${L_BACKGROUND} -d 0 -f ${L_OUTDIR} --doCatMVA --MVAHMC0 0.${C0} --MVAHMC1 0.${M1} --MVALMC0 0.${C1} --MVALMC1 0.${M2} --massNR ${MM} --doSMHiggs --LMLJBTC ${LMLJBTC} --LMSJBTC ${LMSJBTC} --genDiPhotonFilter ;
 
 
-cd ${L_OUTDIR}_HighMass
-hadd LT_output_bbHToGG_M-125_13TeV_amcatnlo.root LT_output_bbHToGG_M-125_4FS_y*
-cd ..
-cd ${L_OUTDIR}_LowMass
-hadd LT_output_bbHToGG_M-125_13TeV_amcatnlo.root LT_output_bbHToGG_M-125_4FS_y*
-cd ..
+#cd ${L_OUTDIR}_HighMass
+#hadd LT_output_bbHToGG_M-125_13TeV_amcatnlo.root LT_output_bbHToGG_M-125_4FS_y*
+#cd ..
+#cd ${L_OUTDIR}_LowMass
+#hadd LT_output_bbHToGG_M-125_13TeV_amcatnlo.root LT_output_bbHToGG_M-125_4FS_y*
+#cd ..
 
-python scripts/RunnerOfLimitsCustom.py --dirname ${L_OUTDIR}
+
+#python scripts/RunnerOfLimitsCustom.py --dirname ${L_OUTDIR}
 
 
 done

--- a/MORIOND17_MakeNonResLimitTrees.sh
+++ b/MORIOND17_MakeNonResLimitTrees.sh
@@ -28,7 +28,7 @@ do
 #samples on EOS
     
     
-    # L_SIGNAL=root://eoscms.cern.ch//eos/cms/store/group/phys_higgs/resonant_HH/RunII/FlatTrees/2016/April26_Mjj70to190/EGML_Signal_Mjj70to190/Hadd
+    #L_SIGNAL=root://eoscms.cern.ch//eos/cms/store/group/phys_higgs/resonant_HH/RunII/FlatTrees/2016/April26_Mjj70to190/EGML_Signal_Mjj70to190/Hadd
     L_SIGNAL=./FlatTrees-May02-Sig
     L_BACKGROUND=root://eoscms.cern.ch//eos/cms/store/group/phys_higgs/resonant_HH/RunII/FlatTrees/2016/April26_Mjj70to190/EGML_Background_Mjj70to190/Hadd
     L_DATA=root://eoscms.cern.ch//eos/cms/store/group/phys_higgs/resonant_HH/RunII/FlatTrees/2016/April26_Mjj70to190/EGML_Data_Mjj70to190/Hadd

--- a/interface/bbgg2DFitter.h
+++ b/interface/bbgg2DFitter.h
@@ -128,7 +128,7 @@ class bbgg2DFitter {
    void SetVerbosityLevel(Int_t v) {_verbLvl=v;}
    void SetCut(TString cut) {_cut = cut;}
    void SetType(std::string tp) { _signalType = tp; }
-   RooArgSet* defineVariables(); //DONE
+   RooArgSet* defineVariables(bool s); //DONE
    int AddSigData(float mass, TString signalfile); //DONE
    std::vector<float> AddHigData(float mass, TString signalfile, int higgschannel, TString higName); //DONE
    void AddBkgData(TString datafile); //DONE

--- a/python/LimitsUtil.py
+++ b/python/LimitsUtil.py
@@ -3,7 +3,7 @@ import os,sys,json,time,re
 import logging
 from shutil import copy
 from pprint import pformat
-# import pebble as pb
+import getpass
 from multiprocessing import Pool, TimeoutError, current_process
 from HiggsAnalysis.bbggLimits.DataCardUtils import *
 from HiggsAnalysis.bbggLimits.IOUtils import *
@@ -11,6 +11,8 @@ from HiggsAnalysis.bbggLimits.CombineUtils import *
 
 __BAD__ = 666
 
+username = getpass.getuser()
+print "UserName = ", username
 
 def printTime(t1, t2, log):
   tNew = time.time()
@@ -153,7 +155,7 @@ def runFullChain(opt, Params, point=None, NRgridPoint=-1, extraLabel=''):
     baseFolder="./bbggToolsResults_v"+str(Params['other']["version"])
 
   # Create PID file to track the job:
-  pidfile = "/tmp/PIDs/PoolWorker"+Label+".pid"
+  pidfile = "/tmp/"+username+"/PIDs/PoolWorker"+Label+".pid"
   file(pidfile, 'w').write(str(PID))
 
   procName = current_process().name
@@ -161,7 +163,7 @@ def runFullChain(opt, Params, point=None, NRgridPoint=-1, extraLabel=''):
     logging.basicConfig(level=logLvl,
                         format='%(asctime)s PID:%(process)d %(name)-12s %(levelname)-8s %(message)s',
                         datefmt='%m-%d %H:%M',
-                        filename='/tmp/logs/processLog_'+str(procName)+'.log',
+                        filename='/tmp/'+username+'/logs/processLog_'+str(procName)+'.log',
                         filemode='w')
   except:
     print 'I got excepted!'

--- a/scripts/RunnerOfLimitsCustom.py
+++ b/scripts/RunnerOfLimitsCustom.py
@@ -15,7 +15,7 @@ tempfile= '''
     },
     "other" : {
         "doDoubleSidedCB": 1,
-        "Combinelxbatch" : 1,
+        "Combinelxbatch" : 0,
         "version" : 66,
 	"integratedLumi" : 36.5,
         "energy" : "13TeV",
@@ -25,7 +25,7 @@ tempfile= '''
         "doBands" : 0,
         "ncat" : 2,
         "analysisType" : "fitTo2D_resSearch_withRegKinFit",
-        "doSingleLimit" : 1,
+        "doSingleLimit" : 0,
         "drawSignalFit" : 0,
         "drawBackgroundFit" : 0,
         "useSigTheoryUnc" : 0,

--- a/scripts/limitPlotter.py
+++ b/scripts/limitPlotter.py
@@ -475,7 +475,7 @@ if __name__ == "__main__":
     mg.GetXaxis().SetLimits(-1.3, 1.3)
   mg.GetYaxis().SetTitle('#sigma(pp #rightarrow HH) #times B(HH #rightarrow bb#gamma#gamma)_{95% CL} (fb)')
 
-  mg.SetMaximum(12)
+  mg.SetMaximum(20)
 
   gPad.RedrawAxis()
 

--- a/scripts/makeAllTrees.py
+++ b/scripts/makeAllTrees.py
@@ -65,7 +65,8 @@ if 'nonres' in opt.x:
 
   TreeDir = '/afs/cern.ch/user/a/andrey/work/hh/LimitCode/CMSSW_7_4_7/src/HiggsAnalysis/bbggLimits/FlatTrees-Jan31/'
 
-  SignalFiles = "/output_GluGluToHHTo2B2G_node_THENODE_13TeV-madgraph.root"
+  SignalFiles = "/output_GluGluToHHTo2B2G_node_THENODE_13TeV-madgraph_0.root"
+  # SignalFiles = "/output_GluGluToHHTo2B2G_node_THENODE_13TeV-madgraph.root"
   if opt.signalDir is None:
     Signals = TreeDir + '/SignalGenInfo/'+SignalFiles
   else:

--- a/scripts/pyLimits.py
+++ b/scripts/pyLimits.py
@@ -179,7 +179,7 @@ if __name__ == "__main__":
 
   # Using a modified implementation of [1]:
 
-  print "Running over:", myNodes
+  print "Running over:", res_Nodes, res_Points
 
   pCount=0
   totJobs = len(res_Nodes)+len(res_Points)+len(res_Masses)
@@ -222,7 +222,7 @@ if __name__ == "__main__":
           # print p, p.pid
           if str(p.pid)==PID:
             mainLog.debug('Found it still running indeed! :: %r, %r, %r %r', p, p.pid, p.is_alive(), p.exitcode)
-
+        
             # We can also double-check how long it's been running with system 'ps' command:"
             # tt = str(subprocess.check_output('ps -p "'+str(p.pid)+'" o etimes=', shell=True)).strip()
             # print 'Run time from OS (may be way off the real time..) = ', tt

--- a/scripts/pyLimits.py
+++ b/scripts/pyLimits.py
@@ -5,6 +5,7 @@ import os,sys,json,time,re
 import logging
 from shutil import copy
 from pprint import pformat
+import getpass
 # import pebble as pb
 from multiprocessing import Pool, TimeoutError, current_process
 from HiggsAnalysis.bbggLimits.LimitsUtil import *
@@ -94,6 +95,9 @@ if __name__ == "__main__":
 
   gSystem.Load('libHiggsAnalysisbbggLimits')
 
+  username = getpass.getuser()
+  print "UserName = ", username
+  
   #workingPath = os.getcwd()
   # parentDir = os.path.abspath(os.path.join(workingPath, os.pardir))
   #if opt.verb: print workingPath
@@ -128,8 +132,8 @@ if __name__ == "__main__":
 
   mainLog.info(pformat(opt))
 
-  createDir('/tmp/PIDs/',mainLog,True)
-  createDir('/tmp/logs/',mainLog,True)
+  createDir('/tmp/'+username+'/PIDs/',mainLog,True)
+  createDir('/tmp/'+username+'/logs/',mainLog,True)
 
   res_Masses = []
   if opt.mass!=None:
@@ -210,9 +214,9 @@ if __name__ == "__main__":
         # We know which process gave us an exception: it is "j" in "i", so let's kill it!
         # First, let's get the PID of that process:
         if i==0:
-          pidfile = '/tmp/PIDs/PoolWorker_Node_'+str(j)+'.pid'
+          pidfile = '/tmp/'+username+'/PIDs/PoolWorker_Node_'+str(j)+'.pid'
         elif i==1:
-          pidfile = '/tmp/PIDs/PoolWorker_gridPoint_'+str(j)+'.pid'
+          pidfile = '/tmp/'+username+'/PIDs/PoolWorker_gridPoint_'+str(j)+'.pid'
         PID = None
         if os.path.isfile(pidfile):
           PID = str(open(pidfile).read())


### PR DESCRIPTION
The event weight for a single Higgs samples should be picked up correctly when running with --NRW option. This is fixed here.

Will not merge it yet, waiting for updates from Rafael, avoiding conflicts.