### PR TITLE
Fixing photon smearing issue in limit trees. 

### DIFF
--- a/interface/bbggLTMaker.h
+++ b/interface/bbggLTMaker.h
@@ -1,10 +1,3 @@
-//////////////////////////////////////////////////////////
-// This class has been automatically generated on
-// Mon Mar 14 14:41:41 2016 by ROOT version 5.34/18
-// from TTree bbggLTMaker/Flat tree for HH->bbgg analyses (after pre selection)
-// found on file: /afs/cern.ch/work/r/rateixei/work/DiHiggs/flg76X/CMSSW_7_6_3/src/flashgg/bbggTools/test/RunJobs/mva_sig/Hadd/output_GluGluToRadionToHHTo2B2G_M-300_narrow_13TeV-madgraph.root
-//////////////////////////////////////////////////////////
-
 #ifndef bbggLTMaker_h
 #define bbggLTMaker_h
 
@@ -14,6 +7,8 @@
 #include <TSelector.h>
 #include <TH2F.h>
 #include <TH3F.h>
+#include <iostream>
+#include <fstream>
 
 // Header file for the classes stored in the TTree if any.
 #include <vector>
@@ -43,6 +38,9 @@ public :
 //   Output file and tree
    TTree *outTree;
    TFile *outFile;
+   
+   ofstream f_event_dump;
+   
 
    ULong64_t o_evt;
    UInt_t o_run;
@@ -360,9 +358,10 @@ bbggLTMaker::~bbggLTMaker()
 {
    if (!fChain) return;
    delete fChain->GetCurrentFile();
-//   photonidFile->Close();
-//   csevFile->Close();
-//   effsFile->Close();
+   f_event_dump.close();
+   //   photonidFile->Close();
+   //   csevFile->Close();
+   //   effsFile->Close();
 }
 
 Int_t bbggLTMaker::GetEntry(Long64_t entry)
@@ -422,6 +421,9 @@ void bbggLTMaker::Init(TTree *tree)
    fChain = tree;
    //   fChain->SetMakeClass(1);
 
+
+   fChain->SetBranchAddress("run", &run, &b_run);
+   fChain->SetBranchAddress("event", &event, &b_event);
 
    fChain->SetBranchAddress("gen_mHH", &gen_mHH, &b_gen_mHH);
    fChain->SetBranchAddress("gen_cosTheta", &gen_cosTheta, &b_gen_cosTheta);

--- a/python/DefineScans.py
+++ b/python/DefineScans.py
@@ -17,7 +17,7 @@ scan_2d_fix = {
 
 #1D scan in kappa lambda
 scan_kl = {
-'kl': [float(i)/(2.5) for i in range(-50,51)],
+'kl': [float(i)/(10.0) for i in range(-200,201)],
 'kt': [1.0],
 'cg': [0.0],
 'c2': [0.0],

--- a/scripts/ArwTreesOnLSF.py
+++ b/scripts/ArwTreesOnLSF.py
@@ -5,8 +5,8 @@ import getpass
 username = getpass.getuser()
 cwd = os.getcwd()
 
-D_HM = "/afs/cern.ch/user/a/andrey/work/hh/NewHope_HighMass/"
-D_LM = "/afs/cern.ch/user/a/andrey/work/hh/NewHope_LowMass"
+D_HM = "/afs/cern.ch/user/a/andrey/work/hh/LimitCode/CMSSW_7_4_7/src/HiggsAnalysis/bbggLimits/LT_PhoSmearFix_HighMass"
+D_LM = "/afs/cern.ch/user/a/andrey/work/hh/LimitCode/CMSSW_7_4_7/src/HiggsAnalysis/bbggLimits/LT_PhoSmearFix_LowMass"
 
 FILE = "/LT_output_GluGluToHHTo2B2G_AllNodes.root"
 

--- a/scripts/ArwTreesOnLSF.py
+++ b/scripts/ArwTreesOnLSF.py
@@ -5,8 +5,8 @@ import getpass
 username = getpass.getuser()
 cwd = os.getcwd()
 
-D_HM = "/afs/cern.ch/user/a/andrey/work/hh/LimitCode/CMSSW_7_4_7/src/HiggsAnalysis/bbggLimits/LT_PhoSmearFix_HighMass"
-D_LM = "/afs/cern.ch/user/a/andrey/work/hh/LimitCode/CMSSW_7_4_7/src/HiggsAnalysis/bbggLimits/LT_PhoSmearFix_LowMass"
+D_HM = "/afs/cern.ch/user/a/andrey/work/hh/LimitCode/CMSSW_7_4_7/src/HiggsAnalysis/bbggLimits/LT_EventDump_HighMass"
+D_LM = "/afs/cern.ch/user/a/andrey/work/hh/LimitCode/CMSSW_7_4_7/src/HiggsAnalysis/bbggLimits/LT_EventDump_LowMass"
 
 FILE = "/LT_output_GluGluToHHTo2B2G_AllNodes.root"
 

--- a/scripts/makeAllTrees.py
+++ b/scripts/makeAllTrees.py
@@ -139,11 +139,13 @@ if 'nonres' in opt.x:
     os.system("hadd %s/LT_NR_Nodes_2to13_merged.root %s/LT_output_GluGluToHHTo2B2G_node_[1-9]*.root"%(directory+"_LowMass",  directory+"_LowMass"))
   
   if opt.dataDir != "0":
-    print "DOING LowMassCat Data"
+    print "DOING LowMassCat Data:"
     command = "pyLimitTreeMaker.py -f " + Data + " -o " +   directory+"_LowMass" + " --min 0 --max " + opt.massNR + " --scale 1." + postFix + doPhotonControlRegion
+    print command
     os.system(command)
     print "DOING HighMassCat Data"
     command = "pyLimitTreeMaker.py -f " + Data + " -o " +   directory+"_HighMass" + " --min " + opt.massNR + " --max 35000 --scale 1." + postFix + doPhotonControlRegion 
+    print command
     os.system(command)
 
 elif 'res' in opt.x:

--- a/src/bbggLTMaker.cc
+++ b/src/bbggLTMaker.cc
@@ -36,6 +36,8 @@ void bbggLTMaker::Loop()
   std::cout << "Options:\n\t Mtot min: " << mtotMin << "\n\t Mtot max: " <<  mtotMax << "\n\t isPhotonCR: " << photonCR
 	    << "\n\t Normalization: " << normalization << std::endl;
 
+  f_event_dump.open(outFileName+".event_dump.txt",ofstream::out);
+  
   outFile = new TFile(outFileName.c_str(), "RECREATE");
   outTree = new TTree("TCVARS", "Limit tree for HH->bbgg analyses");
   outTree->Branch("cut_based_ct", &o_category, "o_category/I"); //0: 2btag, 1: 1btag
@@ -200,17 +202,22 @@ void bbggLTMaker::Loop()
 
     o_preweight = genTotalWeight*normalization;
     o_bbMass = dijetCandidate->M();
-    o_ggMass = diphotonCandidate->M();
-    o_bbggMass = diHiggsCandidate->M();
+    o_ggMass = (*leadingPhoton + *subleadingPhoton).M();
+    o_bbggMass = (*dijetCandidate + *leadingPhoton + *subleadingPhoton).M();
     o_ljet_bdis = leadingJet_bDis;
     o_sjet_bdis = subleadingJet_bDis;
     o_isSignal = isSignal;
     o_HHTagger = HHTagger;
 
+    //Double_t mmm = diHiggsCandidate->M();
+    //if( jentry%200 == 0 )
+    // std::cout << "Entry #" << jentry << "  run="<<run<<" event="<<event
+    //		<<"   diHigg="<<mmm<<"  (diJe+pho+pho)="<<o_bbggMass<<endl;
+
     if(doKinFit)
       o_bbggMass = diHiggsCandidate_KF->M();
     if(doMX)
-      o_bbggMass = diHiggsCandidate->M() - dijetCandidate->M() - diphotonCandidate->M() + 250.;
+      o_bbggMass = o_bbggMass - o_bbMass - o_ggMass + 250.;
 
     //mtot cut
     if(o_bbggMass < mtotMin || o_bbggMass > mtotMax) continue;
@@ -316,19 +323,18 @@ void bbggLTMaker::Loop()
       }
     }
 
-    if(doCatNonRes)
-    {
-//       if ( o_category == 2 && leadingJet_bDis > btagWP_tight && subleadingJet_bDis > btagWP_tight) o_category = 0;
-//       if ( o_category == 2 && leadingJet_bDis > btagWP_loose  && leadingJet_bDis < btagWP_tight && subleadingJet_bDis > btagWP_tight) o_category = 1;
-//       if ( o_category == 2 && subleadingJet_bDis > btagWP_loose  && subleadingJet_bDis < btagWP_tight && leadingJet_bDis > btagWP_tight) o_category = 1;
-//       if ( o_category == 2 ) o_category = -1;
-       if ( o_category == 2 && leadingJet_bDis > btagWP_medium && subleadingJet_bDis > btagWP_medium) o_category = 0;
-       if ( o_category == 2 && leadingJet_bDis > btagWP_medium ) o_category = 1;
-       if ( o_category == 2 && subleadingJet_bDis > btagWP_medium ) o_category = 1;
-       if ( o_category == 2 && leadingJet_bDis < btagWP_medium && subleadingJet_bDis < btagWP_medium ) o_category = -1;
+    if(doCatNonRes) {
+      //       if ( o_category == 2 && leadingJet_bDis > btagWP_tight && subleadingJet_bDis > btagWP_tight) o_category = 0;
+      //       if ( o_category == 2 && leadingJet_bDis > btagWP_loose  && leadingJet_bDis < btagWP_tight && subleadingJet_bDis > btagWP_tight) o_category = 1;
+      //       if ( o_category == 2 && subleadingJet_bDis > btagWP_loose  && subleadingJet_bDis < btagWP_tight && leadingJet_bDis > btagWP_tight) o_category = 1;
+      //       if ( o_category == 2 ) o_category = -1;
+      if ( o_category == 2 && leadingJet_bDis > btagWP_medium && subleadingJet_bDis > btagWP_medium) o_category = 0;
+      if ( o_category == 2 && leadingJet_bDis > btagWP_medium ) o_category = 1;
+      if ( o_category == 2 && subleadingJet_bDis > btagWP_medium ) o_category = 1;
+      if ( o_category == 2 && leadingJet_bDis < btagWP_medium && subleadingJet_bDis < btagWP_medium ) o_category = -1;
     }
     else if (doCatLowMass)
-    {
+      {
        if (o_category == 2 && (leadingJet_bDis > btagWP_tight && subleadingJet_bDis > btagWP_loose)) o_category = 0;
        if (o_category == 2 && (subleadingJet_bDis > btagWP_tight && leadingJet_bDis > btagWP_loose)) o_category = 0;
        if (o_category == 2 && (leadingJet_bDis > btagWP_tight && subleadingJet_bDis < btagWP_loose)) o_category = 1;
@@ -392,7 +398,7 @@ void bbggLTMaker::Loop()
     jet1ETA = leadingJet->eta();
     jet2ETA = subleadingJet->eta();
 
-
+    
     // ----------------
     // -- Weights for Non-Res samples are added here
     //------------------------------
@@ -430,14 +436,15 @@ void bbggLTMaker::Loop()
     // ---------------------------
     // Finished with Non-Res weights
     // ---------------------------
-
-
-
+    
     
     //      std::cout << "cosThetaStarCutCats: " << cosThetaStarCutCats << " - - " << cosThetaStarCut << "  - -  " << o_category << std::endl;
-//    if( o_category == 1  && cosThetaStarCutCats > 0 && fabs(CosThetaStar) > fabs(cosThetaStarCut)) continue;
-//    if( o_category == 0  && cosThetaStarCutCats == 2 && fabs(CosThetaStar) > fabs(cosThetaStarCut)) continue;
+    //    if( o_category == 1  && cosThetaStarCutCats > 0 && fabs(CosThetaStar) > fabs(cosThetaStarCut)) continue;
+    //    if( o_category == 0  && cosThetaStarCutCats == 2 && fabs(CosThetaStar) > fabs(cosThetaStarCut)) continue;
     if( fabs(CosThetaStar_CS) > fabs(cosThetaStarCutHigh) ) continue;
+
+    // Put Run number and event number in the file
+    f_event_dump<<run<<" "<<event<<endl;
 
     outTree->Fill();
   }

--- a/src/bbggLTMaker.cc
+++ b/src/bbggLTMaker.cc
@@ -402,12 +402,6 @@ void bbggLTMaker::Loop()
     // ----------------
     // -- Weights for Non-Res samples are added here
     //------------------------------
-
-    // Lumi, devided by the Total number of events in nodes 2-13.
-    // This is needed because those nodes must be merged later for NonRes weighting.
-    // BAD that it's hardcoded, need to set as parameter.
-    // Float_t S = 2.7/597400;
-    
     
     if (doNonResWeights){
       //std::cout << "Doing Non-Resonant Signal weights " << std::endl;
@@ -438,7 +432,7 @@ void bbggLTMaker::Loop()
     // ---------------------------
     
     
-    //      std::cout << "cosThetaStarCutCats: " << cosThetaStarCutCats << " - - " << cosThetaStarCut << "  - -  " << o_category << std::endl;
+    //    std::cout << "cosThetaStarCutCats: " << cosThetaStarCutCats << " - - " << cosThetaStarCut << "  - -  " << o_category << std::endl;
     //    if( o_category == 1  && cosThetaStarCutCats > 0 && fabs(CosThetaStar) > fabs(cosThetaStarCut)) continue;
     //    if( o_category == 0  && cosThetaStarCutCats == 2 && fabs(CosThetaStar) > fabs(cosThetaStarCut)) continue;
     if( fabs(CosThetaStar_CS) > fabs(cosThetaStarCutHigh) ) continue;

--- a/src/bbggLTMaker.cc
+++ b/src/bbggLTMaker.cc
@@ -444,7 +444,8 @@ void bbggLTMaker::Loop()
     if( fabs(CosThetaStar_CS) > fabs(cosThetaStarCutHigh) ) continue;
 
     // Put Run number and event number in the file
-    f_event_dump<<run<<" "<<event<<endl;
+    if (o_category != -1)
+      f_event_dump<<run<<" "<<event<<endl;
 
     outTree->Fill();
   }


### PR DESCRIPTION
This supposed to mitigate a bug in the photon smearing implementation: instead of using diPhotons object, we can use single photons instead.

In addition, trying to understand the issue #21 by printing out run and even numbers